### PR TITLE
feat(AbstractControlGroup): support objects as options; add tooltip

### DIFF
--- a/src/components/AbstractControlGroup.js
+++ b/src/components/AbstractControlGroup.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import * as Styles from '../shared/Styles'
 import PropTypes from 'prop-types';
+import Tooltip from './Tooltip';
 
 const GLYPH_SIZE = '20px';
 const GLYPH_GAP = '1ch';
@@ -66,14 +67,22 @@ const getOptions = (options, name, ToggleControl, type) => {
         <StyledToggleWrapper key={index}>
           <StyledInput
             name={name}
-            id={`${name}-radio-${index}`}
+            id={item.id || `${name}-radio-${index}`}
             type={type}
-            value={item}
+            value={item.value}
           />
           {ToggleControl}
           <StyledLabel htmlFor={`${name}-radio-${index}`}>
-            {item}
+            {item.text}
           </StyledLabel>
+          {
+            item.tooltip
+            ? <Tooltip
+                showIndicator={true}
+                text={item.tooltip}
+              />
+            : null
+          }
         </StyledToggleWrapper>
       ))}
     </React.Fragment>
@@ -96,7 +105,16 @@ class AbstractControlGroup extends React.Component {
 AbstractControlGroup.propTypes = {
   id: PropTypes.string,
   legend: PropTypes.node,
-  options: PropTypes.array,
+  options: 
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string,
+        error: PropTypes.bool,
+        text: PropTypes.node,
+        tooltip: PropTypes.node,
+        value: PropTypes.string,
+      })
+    ),
   ToggleControl: PropTypes.func,
   type: PropTypes.oneOf(['radio', 'checkbox']),
 }

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -65,6 +65,11 @@ storiesOf('CheckboxGroup', module)
       id="doh"
       legend="Choose all that apply"
       options={['Time', 'Cost', 'Quality']}
+      options={[
+        { text: <>Time <sup>⌛</sup></>, value: 'time' },
+        { text: <>Cost <sup>💰</sup></>, value: 'cost' },
+        { text: 'Quality', value: 'quality' },
+      ]}
     />
   ));
 
@@ -185,6 +190,10 @@ storiesOf('RadioGroup', module)
     <RadioGroup
       id="gah"
       legend="Choose one"
-      options={['Flight', 'Invisibility', 'Telekinesis']}
+      options={[
+        { text: 'Flight', value: 'flight' },
+        { text: 'Invisibility', value: 'invisibility' },
+        { text: <>Telekinesis <s>ooooo</s></>, value: 'telekinesis', tooltip: 'Spooky' },
+      ]}
     />
   ));


### PR DESCRIPTION
The `options` prop is now a `shape` (also, now with support for an optional `tooltip` per option). Works for both radios and checkboxes