### PR TITLE
feat(Autocomplete): Add datalist support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "datalist-polyfill": "^1.23.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.0",

--- a/src/components/LabeledControl.js
+++ b/src/components/LabeledControl.js
@@ -35,6 +35,10 @@ const sharedInputStyles = css`
 const StyledInput = styled.input`
   ${sharedInputStyles};
   line-height: ${Styles.CONTROL_HEIGHT};
+
+  &::-webkit-calendar-picker-indicator {
+    display: none;
+  }
 `;
 
 const StyledTextarea = styled.textarea`
@@ -43,6 +47,21 @@ const StyledTextarea = styled.textarea`
   padding-top: calc(${Styles.CONTROL_HEIGHT} / 3);
 `;
 
+const StyledFieldWrapper = styled.div`
+  display: inline-block;
+  position: relative;
+
+  &::after {
+    color: currentColor;
+    content: '▾';
+    display: ${props => !props.list && 'none'};
+    pointer-events: none;
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+`;
 
 const LabeledControlContext = React.createContext();
 
@@ -54,7 +73,13 @@ class LabeledControl extends React.Component {
       <LabeledControlContext.Provider value={{ id, label, type, value, required, error, description, ...inputProps }}>
         <StyledLabelFieldPair>
           <StyledLabel htmlFor={id}>{label} {required ? '*' : null}</StyledLabel>
-          { type === 'textarea' ? <ContextualTextarea {...inputProps} /> : <ContextualInput {...inputProps} /> }
+          <StyledFieldWrapper {...inputProps}>
+            {
+              type === 'textarea'
+                ? <ContextualTextarea {...inputProps} />
+                : <ContextualInput {...inputProps} />
+            }
+          </StyledFieldWrapper>
           {
             description 
             ? <StyledSmall id={`${id}-desc`}>{description}</StyledSmall>

--- a/src/components/LabeledControl.js
+++ b/src/components/LabeledControl.js
@@ -73,7 +73,7 @@ LabeledControl.propTypes = {
   required: PropTypes.bool.isRequired,
   error: PropTypes.bool.isRequired,
   description: PropTypes.string, 
-  Slot: PropTypes.func,
+  Slot: PropTypes.object,
   value: PropTypes.string,
 };
 
@@ -82,7 +82,6 @@ LabeledControl.defaultProps = {
   type: 'text',
   error: false,
 };
-
 
 const ContextualInput = () => {
   return (

--- a/src/components/LabeledControl.js
+++ b/src/components/LabeledControl.js
@@ -73,6 +73,7 @@ LabeledControl.propTypes = {
   required: PropTypes.bool.isRequired,
   error: PropTypes.bool.isRequired,
   description: PropTypes.string, 
+  Slot: PropTypes.func,
   value: PropTypes.string,
 };
 
@@ -87,16 +88,19 @@ const ContextualInput = () => {
   return (
   // to be clear, this component knows nothing
   <LabeledControlContext.Consumer>
-    {({ id, label, type, value, required, error, description, ...rest }) => (
-      <StyledInput
-        {...rest}
-        type={type}
-        id={id}
-        required={required}
-        data-error={error}
-        aria-describedby={description ? `${id}-desc` : null}
-        value={value}
-      />
+    {({ id, label, type, value, required, error, description, Slot, ...rest }) => (
+      <>
+        <StyledInput
+          {...rest}
+          type={type}
+          id={id}
+          required={required}
+          data-error={error}
+          aria-describedby={description ? `${id}-desc` : null}
+          value={value}
+        />
+        {Slot}
+      </>
     )}
   </LabeledControlContext.Consumer>
 )};

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -1,3 +1,4 @@
+import 'datalist-polyfill';
 import React from 'react';
 
 import { setAddon, storiesOf } from '@storybook/react';

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -170,6 +170,24 @@ storiesOf('Form fields', module)
       defaultValue="Hacksaw"
     />
   ))
+
+  .addWithJSX('autocomplete', () => (
+    <LabeledControl
+      autocomplete="off"
+      id="lizst"
+      label="Type ahead"
+      list="franz"
+      Slot={
+        <datalist id="franz">
+          <option value="Abacus" />
+          <option value="Dennis" />
+          <option value="Ferdinand" />
+          <option value="Zeppelin" />
+        </datalist>
+      }
+    />
+  ))
+
   .addWithJSX('textarea', () => (
     <LabeledControl
       id="bear"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4161,6 +4161,11 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+datalist-polyfill@^1.23.3:
+  version "1.23.3"
+  resolved "https://registry.yarnpkg.com/datalist-polyfill/-/datalist-polyfill-1.23.3.tgz#6b34c8684c9e52c9506ba8550272fad5ca13d79f"
+  integrity sha512-kE11GGSQ1y2JtbwAe8h7yV/lvyhCplnAQ3R7iWmJ+/1mWbjZ9c0eeN0YlUIRkHOUu0XMKqdMklgYnM3cPSQsIA==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"


### PR DESCRIPTION
* Extends `LabeledControl` with a `Slot` prop to support native datalist for an Autocomplete component
* Adds `datalist-polyfill` to support Safari and IE
